### PR TITLE
Add branch name for push event

### DIFF
--- a/.github/workflows/ts.yaml
+++ b/.github/workflows/ts.yaml
@@ -72,7 +72,9 @@ jobs:
           case "${{ github.event_name }}" in
             issue_comment )     branch=${{ steps.comment-branch.outputs.head_ref }} ;;
             workflow_dispatch ) branch=${GITHUB_REF#refs/heads/} ;;
-            * )                 branch=${{ github.head_ref }} ;;
+            pull_request )      branch=${{ github.head_ref }} ;;
+            push )              branch=${{ github.ref_name }} ;;
+            * )                 exit 1 ;;
           esac
           echo "::set-output name=branch::${branch}"
 


### PR DESCRIPTION
SSIA

https://dev.classmethod.jp/articles/how-to-get-a-ref-branch-within-a-workflow-execution-in-github-actions/